### PR TITLE
Fix multiprocessing to always use the spawn start method

### DIFF
--- a/cogment_lab/core.py
+++ b/cogment_lab/core.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import abc
 import copy
 import logging
-from typing import Awaitable, Callable, Generic, TypeVar
+from typing import Awaitable, Callable, Dict, Generic, TypeVar
 
 import cogment
 import numpy as np
@@ -30,14 +30,14 @@ from cogment_lab.specs import AgentSpecs
 
 
 Action = TypeVar("Action")
-Actions = dict[str, Action]
+Actions = Dict[str, Action]
 
 Observation = TypeVar("Observation")
-Observations = dict[str, Observation]
+Observations = Dict[str, Observation]
 
-Rewards = dict[str, float]
+Rewards = Dict[str, float]
 
-Dones = dict[str, bool]
+Dones = Dict[str, bool]
 
 
 class State:

--- a/cogment_lab/envs/pettingzoo.py
+++ b/cogment_lab/envs/pettingzoo.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 from typing import Any, TypedDict
 

--- a/cogment_lab/process_manager.py
+++ b/cogment_lab/process_manager.py
@@ -57,7 +57,7 @@ class Cogment:
         user_id: str = "cogment_lab",
         torch_mode: bool = False,
         log_dir: str | None = None,
-        mp_method: str | None = None,
+        mp_method: str = "spawn",
         orchestrator_port: int = 9000,
         datastore_port: int = 9003,
     ):
@@ -67,8 +67,12 @@ class Cogment:
             user_id (str, optional): User ID. Defaults to "cogment_lab".
             torch_mode (bool, optional): Whether to use PyTorch multiprocessing. Defaults to False.
             log_dir (str, optional): Directory to store logs. Defaults to "logs".
-            mp_method (str | None, optional): Multiprocessing method to use. Defaults to None.
+            mp_method (str, optional): Multiprocessing method to use. Defaults to "spawn". WARNING: Methods other than spawn are likely to not work. Use at your own risk.
         """
+        try:
+            mp.set_start_method(mp_method)
+        except RuntimeError:
+            pass
         self.processes: dict[ImplName, Process] = {}
         self.tasks: dict[ImplName, Task] = {}
 
@@ -132,7 +136,7 @@ class Cogment:
 
             p = TorchProcess(target=target, args=args)
         else:
-            p = self.mp_ctx.Process(target=target, args=args)  # type: ignore
+            p = self.mp_ctx.Process(target=target, args=args, name=f"cogment_lab_{name}")  # type: ignore
         p.start()
         self.processes[name] = p
 

--- a/cogment_lab/specs/action_space.py
+++ b/cogment_lab/specs/action_space.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import gymnasium as gym
 

--- a/cogment_lab/specs/action_space.py
+++ b/cogment_lab/specs/action_space.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import annotations
 
 import gymnasium as gym


### PR DESCRIPTION
It turns out that GRPC doesn't play nice with the fork start method, and it gets invoked even if the context is manually set to spawn.

This should hopefully resolve that issue, making cogment-lab work properly on linux[.](https://news.ycombinator.com/item?id=6277943)